### PR TITLE
Fix `Config` section formatting in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ Config
 
 The `config.ini` should be generated once the controller reports the first
 zone name. However, here is a full `config.ini` if you want to pre-populate
-it with zone names:
+it with zone names::
 
  [config]
  # max_zone is the highest numbered zone you have populated

--- a/README.rst
+++ b/README.rst
@@ -79,8 +79,8 @@ You should now be able to conect to the pynx584 Docker container via its exposed
 Config
 ------
 
-The config.ini should be generated once the controller reports the first
-zone name. However, here is a full config.ini if you want to pre-populate
+The `config.ini` should be generated once the controller reports the first
+zone name. However, here is a full `config.ini` if you want to pre-populate
 it with zone names:
 
  [config]


### PR DESCRIPTION
Hey @kk7ds - this is a small bug fix in the README. The [config] section at the bottom wasn't displaying properly in GitHub.

Also, I was wondering. Where in the filesystem should the `config.ini` file live? I'll add a Docker environment variable for the config.ini file once I know this.

Thanks so much!