### PR TITLE
Allow zone name updates configuration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -87,7 +87,7 @@ it with zone names::
  # max_zone is the highest numbered zone you have populated
  max_zone = 5
 
- # Disable zone name updates from NX8 system. If your system don't set zone
+ # Disable zone name updates from NX8 system. If your system doesn't set zone
  # names and you prefer define them through pynx584, set this value to False.
  # Defaults to True
  # zone_name_update = False

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,11 @@ it with zone names::
  # max_zone is the highest numbered zone you have populated
  max_zone = 5
 
+ # Disable zone name updates from NX8 system. If your system don't set zone
+ # names and you prefer define them through pynx584, set this value to False.
+ # Defaults to True
+ # zone_name_update = False
+
  # Set to true if your unit sends DD/MM dates instead of MM/DD
  euro_date_format = False
  

--- a/nx584/controller.py
+++ b/nx584/controller.py
@@ -346,6 +346,13 @@ class NXController(object):
         return self.users[number]
 
     def process_msg_3(self, frame):
+        try:
+            zone_name_update = self._config.getboolean('config', 'zone_name_update')
+        except configparser.NoOptionError:
+            zone_name_update = True
+            self._config.set('config', 'zone_name_update', zone_name_update)
+        if not zone_name_update:
+            return
         # Zone Name
         number = frame.data[0] + 1
         name = ''.join([chr(x) for x in frame.data[1:]])

--- a/nx584/controller.py
+++ b/nx584/controller.py
@@ -194,6 +194,10 @@ class NXController(object):
         LOG.info('Loaded extensions %s' % ext_mgr.names())
         self._load_config()
         self.event_queue = event_queue.EventQueue(100)
+        try:
+            self.zone_name_update = self._config.getboolean('config', 'zone_name_update')
+        except configparser.NoOptionError:
+            self.zone_name_update = True
 
     def connect(self):
         if '/' in self._portspec[0]:
@@ -346,20 +350,16 @@ class NXController(object):
         return self.users[number]
 
     def process_msg_3(self, frame):
-        try:
-            zone_name_update = self._config.getboolean('config', 'zone_name_update')
-        except configparser.NoOptionError:
-            zone_name_update = True
-            self._config.set('config', 'zone_name_update', zone_name_update)
-        if not zone_name_update:
-            return
         # Zone Name
         number = frame.data[0] + 1
         name = ''.join([chr(x) for x in frame.data[1:]])
         LOG.info('Zone %i: %s' % (number, repr(name.strip())))
-        self._get_zone(number).name = name.strip()
-        LOG.debug('Zone info from %s' % self.zones.keys())
-        self._write_config()
+        if self.zone_name_update:
+            self._get_zone(number).name = name.strip()
+            LOG.debug('Zone info from %s' % self.zones.keys())
+            self._write_config()
+        else:
+            LOG.debug('Zone name not updating')
 
     def process_msg_4(self, frame):
         # Zone Status

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pynx584',
-      version='0.7',
+      version='0.8',
       description='NX584/NX8E Interface Library and Server',
       author='Dan Smith',
       author_email='dsmith+nx584@danplanet.com',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name='pynx584',
-      version='0.8',
+      version='0.7',
       description='NX584/NX8E Interface Library and Server',
       author='Dan Smith',
       author_email='dsmith+nx584@danplanet.com',


### PR DESCRIPTION
Add a configuration option allowing users to enable or disable
this feature. This change fixes #66 

For example, this config file will disable zone names updates

```
[config]

zone_name_update = False

```

Readme was updated to reflect this change and version is updated in setup.py