### PR TITLE
Binary Protocol Implementation

### DIFF
--- a/nx584/controller.py
+++ b/nx584/controller.py
@@ -198,6 +198,11 @@ class NXController(object):
             self.zone_name_update = self._config.getboolean('config', 'zone_name_update')
         except configparser.NoOptionError:
             self.zone_name_update = True
+        try:
+            self._idle_time_heartbeat_seconds = self._config.getint(
+                'config', 'idle_time_heartbeat_seconds')
+        except configparser.NoOptionError:
+            self._idle_time_heartbeat_seconds = 120
 
     def connect(self):
         if '/' in self._portspec[0]:
@@ -617,7 +622,7 @@ class NXController(object):
         while self.running:
             frame = self.process_next()
             if frame is None:
-                if time.time() - watchdog < 120:
+                if time.time() - watchdog < self._idle_time_heartbeat_seconds:
                     self._run_queue()
                 else:
                     # After time with no activity - generate

--- a/nx584/controller.py
+++ b/nx584/controller.py
@@ -360,6 +360,7 @@ class SerialWrapper(StreamWrapper):
     def _connect(self):
         port, baudrate = self._portspec
         self._s = serial.Serial(port, baudrate, timeout=0.25)
+        return self._s.isOpen();
 
 
 class NXController(object):

--- a/nx584/controller.py
+++ b/nx584/controller.py
@@ -785,6 +785,9 @@ class NXController(object):
         LOG.debug('Sending queued %s' % msg)
         self._send(msg)
 
+    def generate_heartbeat_activity(self):
+        self.get_system_status()
+
     def controller_loop(self):
         self.set_time()
         self.get_system_status()
@@ -811,7 +814,7 @@ class NXController(object):
                     # After time with no activity - generate
                     # something to make sure we are still alive
                     LOG.info('No activity for a while, heartbeating')
-                    self.get_system_status()
+                    self.generate_heartbeat_activity()
                     watchdog = time.time()
                 continue
             watchdog = time.time()
@@ -819,6 +822,7 @@ class NXController(object):
                                                      frame.type_name,
                                                      frame.data))
             if frame.ack_required:
+                LOG.debug('Sending ACK')
                 self.send_ack()
             else:
                 pass

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,0 +1,50 @@
+import io
+import unittest
+import mock
+
+from nx584 import controller
+
+TESTFRAME = [1, 0x7e, 2, 0x7d, 3]
+
+
+class TestProtocols(unittest.TestCase):
+    def test_write_ascii(self):
+        stream = io.BytesIO()
+        proto = controller.NXASCII(stream)
+
+        # Write a test frame
+        proto.write_frame(TESTFRAME)
+
+        # Make sure that the stream got the actual bytes expected
+        length = len(TESTFRAME)
+        s1, s2 = controller.fletcher([length] + TESTFRAME)
+        self.assertEqual(b'\n%02x017E027D03%02x%02x\r' % (length, s1, s2),
+                         stream.getvalue())
+
+        # Reset the stream and read it back
+        stream.seek(0)
+        data = proto.read_frame()
+
+        # Make sure we got the right length, data, and checksum
+        self.assertEqual(data, [length] + TESTFRAME + [s1, s2])
+
+    def test_write_binary(self):
+        stream = io.BytesIO()
+        proto = controller.NXBinary(stream)
+
+        # Write a test frame
+        proto.write_frame(TESTFRAME)
+
+        # Make sure that the stream got the actual bytes expected
+        length = len(TESTFRAME)
+        s1, s2 = controller.fletcher([length] + TESTFRAME)
+        self.assertEqual(b'\x7e' + bytes([length]) +
+                         b'\x01\x7d\x5e\x02\x7d\x5d\x03' + bytes([s1, s2]),
+                         stream.getvalue())
+
+        # Reset the stream and read it back
+        stream.seek(0)
+        data = proto.read_frame()
+
+        # Make sure we got the right length, data, and checksum
+        self.assertEqual(data, [length] + TESTFRAME + [s1, s2])

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,10 +1,13 @@
 import io
+import logging
 import unittest
 import mock
+import tempfile
 
 from nx584 import controller
 
 TESTFRAME = [1, 0x7e, 2, 0x7d, 3]
+logging.basicConfig(level=logging.DEBUG)
 
 
 class TestProtocols(unittest.TestCase):
@@ -48,3 +51,141 @@ class TestProtocols(unittest.TestCase):
 
         # Make sure we got the right length, data, and checksum
         self.assertEqual(data, [length] + TESTFRAME + [s1, s2])
+
+
+class SplitIO(io.BytesIO):
+    def __init__(self, r, w):
+        self.r = r
+        self.w = w
+
+    def read(self, n):
+        return self.r.read(n)
+
+    def write(self, b):
+        return self.w.write(b)
+
+
+def get_wrapper(config):
+    rio = io.BytesIO()
+    wio = io.BytesIO()
+
+    class FakeWrapper(controller.StreamWrapper):
+        def _connect(self):
+            self._s = SplitIO(rio, wio)
+            return True
+
+    return rio, wio, FakeWrapper('fakeport', config)
+
+
+class TestController(unittest.TestCase):
+    def setUp(self):
+        with mock.patch('stevedore.extension.ExtensionManager'):
+            with tempfile.NamedTemporaryFile() as f:
+                self.ctrl = controller.NXController('fakeport', f.name)
+
+    def _run_until_idle(self):
+        def stop():
+            self.ctrl.running = False
+
+        self.ctrl.running = True
+        self.ctrl._idle_time_heartbeat_seconds = 0.1
+        self.ctrl._config.set('config', 'max_zone', '2')
+
+        with mock.patch.object(self.ctrl, 'generate_heartbeat_activity',
+                               side_effect=stop):
+            self.ctrl.controller_loop()
+
+    def _test_startup(self, binary):
+        fake_config = mock.MagicMock()
+        fake_config.getboolean.return_value = binary
+        rio, wio, self.ctrl._ser = get_wrapper(fake_config)
+
+        self._run_until_idle()
+
+        expected = [
+            '0128292A',   # system status
+            '022400264E', # zone 1 status
+            '022300254C', # zone 1 name
+            '022401274F', # zone 2 status
+            '022301264D', # zone 2 name
+        ]
+
+        return expected, wio
+
+    def test_startup_ascii(self):
+        expected, wio = self._test_startup(False)
+
+        messages = wio.getvalue().split(b'\r')
+
+        # First message is the time/date, which will vary. Make sure
+        # it looks sane
+        self.assertTrue(messages[0].startswith(b'\n073B'))
+
+        # Check the rest of the messages to make sure they look like
+        # we expect
+        self.assertEqual([b'\n%s' % m.encode() for m in expected],
+                         messages[1:-1])
+
+    def test_startup_binary(self):
+        expected, wio = self._test_startup(True)
+
+        # Use the NXBinary proto adapter to read the stream so we can
+        # compare to the same list of expected messages.
+        wio.seek(0)
+        proto = controller.NXBinary(wio)
+
+        messages = []
+        while True:
+            try:
+                frame = proto.read_frame()
+                messages.append(controller.make_ascii(frame))
+            except controller.ReadTimeout:
+                break
+
+        # First message is the time/date, which will vary. Make sure
+        # it looks sane
+        self.assertTrue(messages[0].startswith('073B'))
+
+        # Check the rest of the messages to make sure they look like
+        # we expect
+        self.assertEqual(expected, messages[1:])
+
+    def _test_receive(self, binary):
+        fake_config = mock.MagicMock()
+        fake_config.getboolean.return_value = binary
+        rio, wio, self.ctrl._ser = get_wrapper(fake_config)
+
+        messages = [
+            # Partitions status
+            [0x87, 0x47, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+            # Partitions snapshot
+            [0x86, 0x00, 0x68, 0x00, 0xE0, 0x40, 0x62, 0x04, 0x82, 0x02, 0x07],
+            # Partitions status
+            [0x87, 0x47, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00],
+        ]
+
+        if binary:
+            proto = controller.NXBinary(rio)
+        else:
+            proto = controller.NXASCII(rio)
+
+        for message in messages:
+            proto.write_frame(message)
+        rio.seek(0)
+
+        self.ctrl.process_msg_7 = None
+        with mock.patch.object(self.ctrl, 'process_msg_7') as pm:
+            with mock.patch.object(self.ctrl, 'send_ack') as sa:
+                self._run_until_idle()
+                self.assertEqual(2, pm.call_count)
+                sa.assert_has_calls([mock.call(), mock.call()])
+
+        return rio.getvalue()
+
+    def test_receive_ascii(self):
+        buf = self._test_receive(False)
+        print('Test buffer is %r' % buf)
+
+    def test_receive_binary(self):
+        buf = self._test_receive(True)
+        print('Test buffer is %r' % list(buf))


### PR DESCRIPTION
@kk7ds  Here are some proposed updates to implement the binary version of the NX584 Home Automation protocol.  This update not only enables the binary functionality for the NX584/NX8E, but also allows pynx584 to run using the NX590E/NX590NE since it supports the binary version of the automation protocol over TCP/IP.

Two new config file entries are used to support this, both in the existing "Config" section:

```
# Set To true if using binary protocol
# Defaults to False
use_binary_protocol = True

# Length of idle time before sending heartbeat keep alive
idle_time_heartbeat_seconds = 20
```

I added the idle_time_heartbeat_seconds for the NX590, it seems to have a short idle timeout/disconnect period.

I've tested using both Serial and TCP/IP connections, using an NX584 in both ASCII and binary mode and also an NX590 (it only supports binary mode over TCP/IP).  I know this is a decent amount of code, and I don't know how much time you/others are still willing to put into this...but hopefully people will find this useful.

Thank you for all your great work on this amazing piece of software.