### PR TITLE
use the new unittest.mock from standard library

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,6 +14,6 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install python3-requests python3-stevedore python3-prettytable python3-serial python3-flask python3-pytest python3-mock
+          sudo apt-get install python3-requests python3-stevedore python3-prettytable python3-serial python3-flask python3-pytest
           pytest-3 tests
           

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -1,8 +1,8 @@
 import io
 import logging
 import unittest
-import mock
 import tempfile
+from unittest import mock
 
 from nx584 import controller
 

--- a/tests/test_event_queue.py
+++ b/tests/test_event_queue.py
@@ -1,5 +1,5 @@
 import unittest
-import mock
+from unittest import mock
 
 from nx584 import event_queue
 


### PR DESCRIPTION
Dear Maintainer,

The old fossilizied `python3-mock` is slowly being removed from Debian